### PR TITLE
Made some references be const to fix compiler errors

### DIFF
--- a/chapter04/scenealphatest.cpp
+++ b/chapter04/scenealphatest.cpp
@@ -40,7 +40,7 @@ void SceneAlphaTest::initScene()
     try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 
@@ -65,7 +65,7 @@ void SceneAlphaTest::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 

--- a/chapter04/scenemultitex.cpp
+++ b/chapter04/scenemultitex.cpp
@@ -41,7 +41,7 @@ void SceneMultiTex::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 
@@ -66,7 +66,7 @@ void SceneMultiTex::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 

--- a/chapter04/scenenormalmap.cpp
+++ b/chapter04/scenenormalmap.cpp
@@ -40,7 +40,7 @@ void SceneNormalMap::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 
@@ -65,7 +65,7 @@ void SceneNormalMap::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 

--- a/chapter04/sceneprojtex.cpp
+++ b/chapter04/sceneprojtex.cpp
@@ -47,7 +47,7 @@ void SceneProjTex::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 

--- a/chapter04/scenereflectcube.cpp
+++ b/chapter04/scenereflectcube.cpp
@@ -61,7 +61,7 @@ void SceneReflectCube::loadCubeMap( const char * baseFileName )
 		try {
 			glimg::ImageSet * imgSet;
 			imgSet = glimg::loaders::stb::LoadFromFile(texName.c_str());
-			glimg::SingleImage &img = imgSet->GetImage(0);
+			const glimg::SingleImage &img = imgSet->GetImage(0);
 			glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 			glimg::Dimensions dims = img.GetDimensions();
 

--- a/chapter04/scenerefractcube.cpp
+++ b/chapter04/scenerefractcube.cpp
@@ -61,7 +61,7 @@ void SceneRefractCube::loadCubeMap( const char * baseFileName )
 		try {
 			glimg::ImageSet * imgSet;
 			imgSet = glimg::loaders::stb::LoadFromFile(texName.c_str());
-			glimg::SingleImage &img = imgSet->GetImage(0);
+			const glimg::SingleImage &img = imgSet->GetImage(0);
 			glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 			glimg::Dimensions dims = img.GetDimensions();
 

--- a/chapter04/scenetexture.cpp
+++ b/chapter04/scenetexture.cpp
@@ -38,7 +38,7 @@ void SceneTexture::initScene()
 	try {
 		glimg::ImageSet * imgSet;
 		imgSet = glimg::loaders::stb::LoadFromFile(texName);
-		glimg::SingleImage &img = imgSet->GetImage(0);
+		const glimg::SingleImage &img = imgSet->GetImage(0);
 		glimg::OpenGLPixelTransferParams params = glimg::GetUploadFormatType(img.GetFormat(), 0);
 		glimg::Dimensions dims = img.GetDimensions();
 


### PR DESCRIPTION
Was getting compiler errors

scenereflectcube.cpp:64: error: invalid initialization of non-const reference of type ‘glimg::SingleImage&’ from a temporary of type ‘glimg::SingleImage’

After inspecting the code - it looks like they're okay to be made const, ch04 compiled fine after that.
