### PR TITLE
Cmake copy dirs - for out of tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,3 +50,4 @@ add_subdirectory( chapter08 )
 add_subdirectory( chapter09 )
 add_subdirectory( chapter10 )
 
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/media DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter01/CMakeLists.txt
+++ b/chapter01/CMakeLists.txt
@@ -8,3 +8,5 @@ set( chapter01_SOURCES
 
 add_executable( chapter01 ${chapter01_SOURCES} )
 target_link_libraries( chapter01 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter02/CMakeLists.txt
+++ b/chapter02/CMakeLists.txt
@@ -9,3 +9,5 @@ set( chapter02_SOURCES
 
 add_executable( chapter02 ${chapter02_SOURCES} )
 target_link_libraries( chapter02 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter03/CMakeLists.txt
+++ b/chapter03/CMakeLists.txt
@@ -9,3 +9,5 @@ set( chapter03_SOURCES
 
 add_executable( chapter03 ${chapter03_SOURCES} )
 target_link_libraries( chapter03 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter04/CMakeLists.txt
+++ b/chapter04/CMakeLists.txt
@@ -13,3 +13,5 @@ set( chapter04_SOURCES
 
 add_executable( chapter04 ${chapter04_SOURCES} )
 target_link_libraries( chapter04 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter05/CMakeLists.txt
+++ b/chapter05/CMakeLists.txt
@@ -1,13 +1,15 @@
-set( chapter05_SOURCES 	
+set( chapter05_SOURCES
 	main.cpp
 	sceneblur.cpp
 	scenedeferred.cpp
 	sceneedge.cpp
 	scenegamma.cpp
 	scenemsaa.cpp
-        scenetonemap.cpp
-        scenehdrbloom.cpp
-        sceneoit.cpp)
+	scenetonemap.cpp
+	scenehdrbloom.cpp
+	sceneoit.cpp)
 
 add_executable( chapter05 ${chapter05_SOURCES} )
 target_link_libraries( chapter05 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter06/CMakeLists.txt
+++ b/chapter06/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( chapter06_SOURCES 	
+set( chapter06_SOURCES
 	scenebezcurve.cpp
 	main.cpp
 	scenepointsprite.cpp
@@ -10,3 +10,5 @@ set( chapter06_SOURCES
 
 add_executable( chapter06 ${chapter06_SOURCES} )
 target_link_libraries( chapter06 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter07/CMakeLists.txt
+++ b/chapter07/CMakeLists.txt
@@ -5,8 +5,9 @@ set( chapter07_SOURCES
 	scenejitter.cpp
 	scenepcf.cpp
 	sceneshadowmap.cpp
-        sceneshadowvolume.cpp 
-        )
+	sceneshadowvolume.cpp )
 
 add_executable( chapter07 ${chapter07_SOURCES} )
 target_link_libraries( chapter07 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter08/CMakeLists.txt
+++ b/chapter08/CMakeLists.txt
@@ -6,8 +6,10 @@ set( chapter08_SOURCES
 	scenenightvision.cpp
 	scenepaint.cpp
 	scenewood.cpp
-        scenenoise.cpp
+	scenenoise.cpp
 )
 
 add_executable( chapter08 ${chapter08_SOURCES} )
 target_link_libraries( chapter08 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter09/CMakeLists.txt
+++ b/chapter09/CMakeLists.txt
@@ -10,3 +10,5 @@ set( chapter09_SOURCES
 
 add_executable( chapter09 ${chapter09_SOURCES} )
 target_link_libraries( chapter09 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/chapter10/CMakeLists.txt
+++ b/chapter10/CMakeLists.txt
@@ -1,9 +1,11 @@
 set( chapter10_SOURCES 
 	main.cpp
 	scenemandelbrot.cpp
-        scenecloth.cpp
-        sceneparticles.cpp
+	scenecloth.cpp
+	sceneparticles.cpp
 )
 
 add_executable( chapter10 ${chapter10_SOURCES} )
 target_link_libraries( chapter10 ${GLSLCOOKBOOK_LIBS} )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
In each of the chapter directory CMakeLists.txt I added the command `file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shader DESTINATION ${CMAKE_CURRENT_BINARY_DIR})` and in the root CMakeLists.txt I did the same thing for the `media` directory

This allows for out-of-tree builds, which I believe is what issue #9 was referring to.  Please double-check that this works on Windows (I'm on linux), that the copy doesn't seem to do anything if the directory already exists (e.g. in tree builds)

Also, in the root CMakeLists.txt I changed it to use find_package for GLFW and GLM.  The original didn't work for me because on Arch Linux at least, glfw3 has completely replaced glfw2 and the libname is libglfw.so and isn't found when searching for libglfw3.so  This should also be tested on different Linux distributions where glfw3 may not be the default - Debian/Ubuntu etc...
This change may also make the `if( GLFW_SEARCH_PATH )` blocks above not really do anything, but I left them in anyway.  Again, please review and I can change stuff if needed.
