### PR TITLE
Made path work for out-of-tree builds, added glfw for library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 2.8)
 
 project (GLSLCOOKBOOK)
 
-set( CMAKE_MODULE_PATH "cmake/modules" )
+set( CMAKE_MODULE_PATH ${GLSLCOOKBOOK_SOURCE_DIR}/cmake/modules )
 
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING

--- a/cmake/modules/FindGLFW3.cmake
+++ b/cmake/modules/FindGLFW3.cmake
@@ -36,7 +36,7 @@ FIND_PATH(GLFW3_INCLUDE_DIR "GLFW/glfw3.h"
   PATHS ${_glfw3_HEADER_SEARCH_DIRS} )
 
 # Search for the library
-FIND_LIBRARY(GLFW3_LIBRARY NAMES glfw3 
+FIND_LIBRARY(GLFW3_LIBRARY NAMES glfw3 glfw
   PATHS ${_glfw3_LIB_SEARCH_DIRS} )
 
 INCLUDE(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Added glfw to names to search for GLFW_LIBRARY in the FindGLFW3 file,
because the shared library is named libglfw.so.3.0 and not found when
searching for libglfw3
