### PR TITLE
Visual Studio - fixed various issues when compiling on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ if( UNIX )
   list( APPEND GLSLCOOKBOOK_LIBS ${RT_LIB} )
 endif()
 
+if( WIN32 )
+  find_package( OpenGL REQUIRED )
+  list( APPEND GLSLCOOKBOOK_LIBS ${OPENGL_gl_LIBRARY} )
+endif()
+
 include_directories( ${GLSLCOOKBOOK_INCLUDE} )
 
 add_subdirectory( ingredients )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ them working on Windows soon.  Your help is welcome!  Fork
 
 Any problems, create an issue on [github][ghcookbook].
 
+Compiling for Windows with Visual Studio 2012
+---------------------------------------------
+1.  Install [CMake][] win32 installer
+2.  Download [GLFW][] 32-bit Window Libraries and extract to C:\Program Files (x86)\GLFW
+3.  Download [GLM][] and extract to C:\Program Files (x86)\GLM
+4.  Download the example code from [github][ghcookbook], or clone using git.
+5.  Run CMake GUI, point the Source Code directory to the location of the code
+    you downloaded in the previous step (i.e. C:/Users/hp/Git/glslcookbook)
+6.  Point the Build Binaries directory to the location of the code with CMakeFiles
+    appended to it (i.e. C:/Users/hp/Git/glslcookbook/CMakeFiles)
+7.  Click 'Configure'
+8.  Click yes when prompted to create the Build Directory
+9.  Specify Visual Studio 11 (VS 11 == VS 2012, VS10 == VS 2010)
+    with 'Use default native compilers', then click 'Finish'
+10. Once CMake has finished configuring the Project, click 'Generate'
+11. Now open CMakeFiles\GLSLCOOKBOOK.sln
+12. Build the Project
+13. I've found the easiest way to run the examples inside Visual Studio is to right click
+    the chapter that you are interested in and click 'Set as Startup Project', and then
+    right click the chapter again and click 'Properties'.  Under Configuration Properties,
+    click the Debugging option group.  Type the 'Command Argument' of the specific
+    example you are trying to run (i.e. 'ads' for the ambient-diffuse-specular example
+    from Chapter 2).  Now you can Run the Local Windows Debugger and everything should
+    behave as expected.
+
+If you are having trouble with CMake generating the files, double check where you have
+the libraries installed.  If you used a different location to extract GLFW and GLM,
+then you will have to edit 'cmake\modules\FindGLFW3.cmake' and/or 
+'cmake\modules\FindGLM.cmake' making sure that you change all back slashes to 
+forward slashes in each path
+
 OpenGL Function Loading
 -----------------------
 
@@ -41,5 +72,6 @@ be tested with MinGW on Windows.
 [GLM]: http://glm.g-truc.net
 [GLFW]:  http://glfw.org
 [ghcookbook]:  http://github.com/daw42/glslcookbook
-[cookbook]: http://www.packtpub.com/opengl-4-0-shading-language-cookbook/book
+[cookbook]: http://www.packtpub.com/opengl-4-shading-language-cookbook-second-edition/book
 [GLLoadGen]:  https://bitbucket.org/alfonse/glloadgen/wiki/Home
+[CMake]: http://www.cmake.org/cmake/resources/software.html

--- a/cmake/modules/FindGLFW3.cmake
+++ b/cmake/modules/FindGLFW3.cmake
@@ -14,10 +14,12 @@
 # default search dirs
 set( _glfw3_HEADER_SEARCH_DIRS 
   "/usr/include"
-  "/usr/local/include" )
+  "/usr/local/include"
+  "C:/Program Files (x86)/glfw/include" )
 set( _glfw3_LIB_SEARCH_DIRS
   "/usr/lib"
-  "/usr/local/lib" )
+  "/usr/local/lib"
+  "C:/Program Files (x86)/glfw/lib-msvc110" )
 
 # Check environment for root search directory
 set( _glfw3_ENV_ROOT $ENV{GLFW3_ROOT} )

--- a/cmake/modules/FindGLM.cmake
+++ b/cmake/modules/FindGLM.cmake
@@ -32,7 +32,8 @@
 # default search dirs
 SET(_glm_HEADER_SEARCH_DIRS
     "/usr/include"
-    "/usr/local/include")
+    "/usr/local/include"
+    "C:/Program Files (x86)/glm" )
 
 # check environment variable
 SET(_glm_ENV_ROOT_DIR "$ENV{GLM_ROOT_DIR}")

--- a/ingredients/glslprogram.h
+++ b/ingredients/glslprogram.h
@@ -1,6 +1,10 @@
 #ifndef GLSLPROGRAM_H
 #define GLSLPROGRAM_H
 
+#ifdef WIN32
+#pragma warning( disable : 4290 )
+#endif
+
 #include "cookbookogl.h"
 
 #include <string>

--- a/ingredients/glutils.cpp
+++ b/ingredients/glutils.cpp
@@ -8,7 +8,7 @@ using std::string;
 
 namespace GLUtils {
 
-void debugCallback( GLenum source, GLenum type, GLuint id,
+void APIENTRY debugCallback( GLenum source, GLenum type, GLuint id,
 	GLenum severity, GLsizei length, const GLchar * msg, const void * param ) {
 	
 	string sourceStr;

--- a/ingredients/glutils.h
+++ b/ingredients/glutils.h
@@ -9,7 +9,7 @@ namespace GLUtils
     
     void dumpGLInfo(bool dumpExtensions = false);
     
-    void debugCallback( GLenum source, GLenum type, GLuint id,
+    void APIENTRY debugCallback( GLenum source, GLenum type, GLuint id,
 		GLenum severity, GLsizei length, const GLchar * msg, const void * param );
 }
 


### PR DESCRIPTION
Dear David,

I just purchased the edition 2 version and have to say: excellent work!  I am really excited to play around with Compute Shaders, but I am waiting for NVIDIA NSight to support them before using them in production code (I'm addicted to NSight and can't live without it).

This patch should allow compilation of the Cookbook code on Microsoft Windows with Visual Studio 2012.  There are still a lot of warning messages related to various conversions that I might take a look at explicitly casting if I have time.

I have been doing a lot of work with NVIDIA CUDA and have a pretty solid Mesh class built that almost never touches the CPU.  This is a lot faster for computing various elements (computing sphere positions, calculating normals, creating indices, etc).  It might be fun to migrate some of your Mesh code to use Compute Shaders.  It would be especially useful for expensive operations like computing adjacency.

Sincerely,
Wesley
