### PR TITLE
Fix skybox bug

### DIFF
--- a/chapter04/skybox.cpp
+++ b/chapter04/skybox.cpp
@@ -24,7 +24,7 @@ SkyBox::SkyBox()
         side2, -side2, -side2,
        // Left
        -side2, -side2, side2,
-        side2,  side2, side2,
+       -side2,  side2, side2,
        -side2,  side2, -side2,
        -side2, -side2, -side2,
        // Bottom


### PR DESCRIPTION
Missing minus sign on one of the values of the left face of the cube.
Causes a visual bug in the skybox for example in 'scene reflect cube'.